### PR TITLE
LSS-2807: Audit changes

### DIFF
--- a/lib/lossless-v3/contracts/utils/ChainportLERC20.sol
+++ b/lib/lossless-v3/contracts/utils/ChainportLERC20.sol
@@ -1355,7 +1355,7 @@ contract BridgeMintableTokenV2 is ERC20Upgradeable, PausableUpgradeable {
      * @param   key Key to accept
      */
     function acceptRecoveryAdminOwnership(bytes memory key) external {
-        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be canditate");
+        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be candidate");
         require(keccak256(key) == recoveryAdminKeyHash, "LERC20: Invalid key");
         recoveryAdmin = recoveryAdminCandidate;
         recoveryAdminCandidate = address(0);

--- a/lib/lossless-v3/contracts/utils/ChainportLERC20_old.sol
+++ b/lib/lossless-v3/contracts/utils/ChainportLERC20_old.sol
@@ -154,7 +154,7 @@ contract ChainportLERC20 is Context, ILERC20 {
     }
 
     function acceptRecoveryAdminOwnership(bytes memory key) override external {
-        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be canditate");
+        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be candidate");
         require(keccak256(key) == recoveryAdminKeyHash, "LERC20: Invalid key");
         emit NewRecoveryAdmin(recoveryAdminCandidate);
         recoveryAdmin = recoveryAdminCandidate;

--- a/lib/lossless-v3/contracts/utils/LERC20.sol
+++ b/lib/lossless-v3/contracts/utils/LERC20.sol
@@ -108,7 +108,7 @@ contract LERC20 is Context, ILERC20 {
     }
 
     function acceptRecoveryAdminOwnership(bytes memory key) override external {
-        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be canditate");
+        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be candidate");
         require(keccak256(key) == recoveryAdminKeyHash, "LERC20: Invalid key");
         emit NewRecoveryAdmin(recoveryAdminCandidate);
         recoveryAdmin = recoveryAdminCandidate;

--- a/lib/lossless-v3/contracts/utils/LERC20Fees.sol
+++ b/lib/lossless-v3/contracts/utils/LERC20Fees.sol
@@ -110,7 +110,7 @@ contract LERC20Fee is Context, ILERC20 {
     }
 
     function acceptRecoveryAdminOwnership(bytes memory key) override external {
-        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be canditate");
+        require(_msgSender() == recoveryAdminCandidate, "LERC20: Must be candidate");
         require(keccak256(key) == recoveryAdminKeyHash, "LERC20: Invalid key");
         emit NewRecoveryAdmin(recoveryAdminCandidate);
         recoveryAdmin = recoveryAdminCandidate;

--- a/script/deployAdminlessERC20.sol
+++ b/script/deployAdminlessERC20.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../src/Mocks/ERC20Mock.sol";
+
+contract DeployWrappedERC20 is Script {
+    function run() external returns (TestToken) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        return new TestToken("Testing Token", "TEST", type(uint256).max);
+    }
+}

--- a/script/deployAdminlessERC20.sol
+++ b/script/deployAdminlessERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity 0.8.4;
 
 import "forge-std/Script.sol";
 import "../src/Mocks/ERC20Mock.sol";

--- a/script/deployLosslessWrappedERC20.s.sol
+++ b/script/deployLosslessWrappedERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity 0.8.4;
 
 import "forge-std/Script.sol";
 import "../src/LosslessWrappedERC20.sol";

--- a/script/deployLosslessWrappedERC20Ownable.sol
+++ b/script/deployLosslessWrappedERC20Ownable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity 0.8.4;
 
 import "forge-std/Script.sol";
 import "../src/LosslessWrappedERC20Ownable.sol";

--- a/script/deployOwnableERC20.sol
+++ b/script/deployOwnableERC20.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../src/Mocks/ERC20OwnableMock.sol";
+
+contract DeployWrappedERC20 is Script {
+    function run() external returns (OwnableTestToken) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        return new OwnableTestToken("Testing Token", "TEST", type(uint256).max);
+    }
+}

--- a/script/deployOwnableERC20.sol
+++ b/script/deployOwnableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity 0.8.4;
 
 import "forge-std/Script.sol";
 import "../src/Mocks/ERC20OwnableMock.sol";

--- a/src/Interfaces/ILosslessEvents.sol
+++ b/src/Interfaces/ILosslessEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 interface ILosslessEvents {
     event NewAdmin(address indexed _newAdmin);

--- a/src/Interfaces/ILosslessEvents.sol
+++ b/src/Interfaces/ILosslessEvents.sol
@@ -15,4 +15,5 @@ interface ILosslessEvents {
         address indexed to,
         uint256 amount
     );
+    event WithdrawRequestCanceled(address indexed user);
 }

--- a/src/LosslessWrappedERC20.sol
+++ b/src/LosslessWrappedERC20.sol
@@ -268,4 +268,24 @@ contract LosslessWrappedERC20 is
 
         return true;
     }
+
+    /// @notice This function cancels pending withdrawal request
+    function cancelWithdrawRequest() public {
+        Unwrapping storage unwrapping = unwrappingRequests[_msgSender()];
+
+        require(
+            unwrapping.unwrappingAmount > 0,
+            "LSS: No active withdrawal request"
+        );
+
+        require(
+            unwrapping.unwrappingTimestamp > block.timestamp,
+            "LSS: Withdrawal request already executable"
+        );
+
+        unwrapping.unwrappingAmount = 0;
+        unwrapping.unwrappingTimestamp = 0;
+
+        emit WithdrawRequestCanceled(_msgSender());
+    }
 }

--- a/src/LosslessWrappedERC20.sol
+++ b/src/LosslessWrappedERC20.sol
@@ -2,13 +2,18 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "lossless-v3/Interfaces/ILosslessController.sol";
 
 import "./Interfaces/ILosslessEvents.sol";
 
-contract LosslessWrappedERC20 is ERC20Wrapper, ILosslessEvents {
+contract LosslessWrappedERC20 is
+    ERC20Wrapper,
+    ILosslessEvents,
+    ReentrancyGuard
+{
     using SafeERC20 for IERC20;
 
     bool public isLosslessOn = true;
@@ -237,7 +242,7 @@ contract LosslessWrappedERC20 is ERC20Wrapper, ILosslessEvents {
     function withdrawTo(
         address to,
         uint256 amount
-    ) public override returns (bool) {
+    ) public override nonReentrant returns (bool) {
         Unwrapping storage unwrapping = unwrappingRequests[_msgSender()];
 
         require(

--- a/src/LosslessWrappedERC20.sol
+++ b/src/LosslessWrappedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/src/LosslessWrappedERC20.sol
+++ b/src/LosslessWrappedERC20.sol
@@ -41,7 +41,7 @@ contract LosslessWrappedERC20 is
 
     // --- LOSSLESS modifiers ---
 
-    modifier lssAprove(address spender, uint256 amount) {
+    modifier lssApprove(address spender, uint256 amount) {
         if (isLosslessOn) {
             lossless.beforeApprove(_msgSender(), spender, amount);
         }
@@ -137,7 +137,13 @@ contract LosslessWrappedERC20 is
     function approve(
         address spender,
         uint256 amount
-    ) public virtual override(ERC20) lssAprove(spender, amount) returns (bool) {
+    )
+        public
+        virtual
+        override(ERC20)
+        lssApprove(spender, amount)
+        returns (bool)
+    {
         _approve(_msgSender(), spender, amount);
         return true;
     }

--- a/src/LosslessWrappedERC20.sol
+++ b/src/LosslessWrappedERC20.sol
@@ -222,6 +222,9 @@ contract LosslessWrappedERC20 is ERC20Wrapper, ILosslessEvents {
         );
 
         Unwrapping storage unwrapping = unwrappingRequests[_msgSender()];
+
+        require(unwrapping.unwrappingTimestamp == 0, "LSS: Pending withdraw");
+
         unwrapping.unwrappingAmount = amount;
         unwrapping.unwrappingTimestamp = block.timestamp + unwrappingDelay;
 
@@ -248,6 +251,11 @@ contract LosslessWrappedERC20 is ERC20Wrapper, ILosslessEvents {
         );
 
         unwrapping.unwrappingAmount -= amount;
+
+        if (unwrapping.unwrappingAmount == 0) {
+            unwrapping.unwrappingTimestamp = 0;
+        }
+
         _burn(_msgSender(), amount);
         SafeERC20.safeTransfer(underlying, to, amount);
 

--- a/src/LosslessWrappedERC20Ownable.sol
+++ b/src/LosslessWrappedERC20Ownable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "./LosslessWrappedERC20.sol";
 

--- a/src/LosslessWrappedERC20Ownable.sol
+++ b/src/LosslessWrappedERC20Ownable.sol
@@ -70,13 +70,13 @@ contract LosslessWrappedERC20Ownable is LosslessWrappedERC20 {
         emit NewRecoveryAdminProposal(candidate);
     }
 
-    /// @notice This function is for accepting the revoery admin ownership transfer
+    /// @notice This function is for accepting the recovery admin ownership transfer
     /// @dev Only can be called by recovery admin
     /// @param key Key hash to accept transfer
     function acceptRecoveryAdminOwnership(bytes memory key) external {
         require(
             _msgSender() == recoveryAdminCandidate,
-            "LERC20: Must be canditate"
+            "LERC20: Must be candidate"
         );
         require(keccak256(key) == recoveryAdminKeyHash, "LERC20: Invalid key");
         emit NewRecoveryAdmin(recoveryAdminCandidate);

--- a/src/Mocks/ERC20Mock.sol
+++ b/src/Mocks/ERC20Mock.sol
@@ -1,6 +1,6 @@
 // contracts/GLDToken.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/src/Mocks/ERC20OwnableMock.sol
+++ b/src/Mocks/ERC20OwnableMock.sol
@@ -1,6 +1,6 @@
 // contracts/GLDToken.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/adminlessProtectedWLERC20.t.sol
+++ b/test/adminlessProtectedWLERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "./utils/losslessEnv.t.sol";
 

--- a/test/domain based/claimReportRewards.t.sol
+++ b/test/domain based/claimReportRewards.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/claimRetrieveFunds.t.sol
+++ b/test/domain based/claimRetrieveFunds.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/claimStakeReward.t.sol
+++ b/test/domain based/claimStakeReward.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/committeeMemberReward.t.sol
+++ b/test/domain based/committeeMemberReward.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/disputeProposedWallet.t.sol
+++ b/test/domain based/disputeProposedWallet.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/payoutRefund.t.sol
+++ b/test/domain based/payoutRefund.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/proposeRefundWallet.t.sol
+++ b/test/domain based/proposeRefundWallet.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/report.t.sol
+++ b/test/domain based/report.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/resolveReport.t.sol
+++ b/test/domain based/resolveReport.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/secondReport.t.sol
+++ b/test/domain based/secondReport.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/settlementPeriod.t.sol
+++ b/test/domain based/settlementPeriod.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/settlementPeriodChanges.t.sol
+++ b/test/domain based/settlementPeriodChanges.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/unwrapping.t.sol
+++ b/test/domain based/unwrapping.t.sol
@@ -98,4 +98,206 @@ contract UnwrappingToken is LosslessTestEnvironment {
         assertEq(statusE, true);
         vm.stopPrank();
     }
+
+    function testUnwrappingRequestCancel()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        wLERC20a.cancelWithdrawRequest();
+        wLERC20p.cancelWithdrawRequest();
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        wLERC20a.withdrawTo(tokenOwner, 10);
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        wLERC20p.withdrawTo(tokenOwner, 10);
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAfterWithdraw()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        wLERC20a.withdrawTo(tokenOwner, 10);
+        wLERC20p.withdrawTo(tokenOwner, 10);
+
+        vm.expectRevert("LSS: No active withdrawal request");
+        wLERC20a.cancelWithdrawRequest();
+        vm.expectRevert("LSS: No active withdrawal request");
+        wLERC20p.cancelWithdrawRequest();
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAfterDelayPeriodAndNoWithdraw()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        vm.expectRevert("LSS: Withdrawal request already executable");
+        wLERC20a.cancelWithdrawRequest();
+        vm.expectRevert("LSS: Withdrawal request already executable");
+        wLERC20p.cancelWithdrawRequest();
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAndNewRequest()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        wLERC20a.cancelWithdrawRequest();
+        wLERC20p.cancelWithdrawRequest();
+
+        wLERC20a.requestWithdraw(8);
+        wLERC20p.requestWithdraw(8);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 8);
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 8);
+
+        assertEq(statusP, true);
+        assertEq(statusE, true);
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAfterHalfWithdraw()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 5);
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 5);
+
+        vm.expectRevert("LSS: Withdrawal request already executable");
+        wLERC20a.cancelWithdrawRequest();
+        vm.expectRevert("LSS: Withdrawal request already executable");
+        wLERC20a.cancelWithdrawRequest();
+
+        assertEq(statusP, true);
+        assertEq(statusE, true);
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAndNewRequestPreviousAmount()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        wLERC20a.cancelWithdrawRequest();
+        wLERC20p.cancelWithdrawRequest();
+
+        wLERC20a.requestWithdraw(8);
+        wLERC20p.requestWithdraw(8);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 10);
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 10);
+
+        assertEq(statusP, false);
+        assertEq(statusE, false);
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAndNewRequestPreviousAmountInChunks()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        wLERC20a.cancelWithdrawRequest();
+        wLERC20p.cancelWithdrawRequest();
+
+        wLERC20a.requestWithdraw(8);
+        wLERC20p.requestWithdraw(8);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 5);
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 5);
+
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        wLERC20a.withdrawTo(tokenOwner, 5);
+        vm.expectRevert("LSS: Amount exceeds requested amount");
+        wLERC20p.withdrawTo(tokenOwner, 5);
+
+        assertEq(statusP, true);
+        assertEq(statusE, true);
+
+        vm.stopPrank();
+    }
+
+    function testUnwrappingRequestCancelAndNewRequestAmountInChunks()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(10);
+        wLERC20p.requestWithdraw(10);
+
+        wLERC20a.cancelWithdrawRequest();
+        wLERC20p.cancelWithdrawRequest();
+
+        wLERC20a.requestWithdraw(8);
+        wLERC20p.requestWithdraw(8);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 5);
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 5);
+
+        statusE = wLERC20a.withdrawTo(tokenOwner, 3);
+        statusE = wLERC20p.withdrawTo(tokenOwner, 3);
+
+        assertEq(statusP, true);
+        assertEq(statusE, true);
+
+        vm.stopPrank();
+    }
 }

--- a/test/domain based/unwrapping.t.sol
+++ b/test/domain based/unwrapping.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/domain based/unwrapping.t.sol
+++ b/test/domain based/unwrapping.t.sol
@@ -74,4 +74,28 @@ contract UnwrappingToken is LosslessTestEnvironment {
 
         vm.stopPrank();
     }
+
+    function testUnwrappingRequestWithPendingRequest()
+        public
+        withProtectedWrappedToken
+        withAdminlessProtectedWrappedToken
+    {
+        vm.startPrank(tokenOwner);
+        wLERC20a.requestWithdraw(5);
+        wLERC20p.requestWithdraw(5);
+
+        vm.expectRevert("LSS: Pending withdraw");
+        wLERC20a.requestWithdraw(5);
+        vm.expectRevert("LSS: Pending withdraw");
+        wLERC20p.requestWithdraw(5);
+
+        vm.warp(block.timestamp + unwrappingDelay + 1 minutes);
+
+        bool statusE = wLERC20a.withdrawTo(tokenOwner, 5);
+        bool statusP = wLERC20p.withdrawTo(tokenOwner, 5);
+
+        assertEq(statusP, true);
+        assertEq(statusE, true);
+        vm.stopPrank();
+    }
 }

--- a/test/domain based/voteOnReport.t.sol
+++ b/test/domain based/voteOnReport.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "../utils/losslessEnv.t.sol";
 

--- a/test/environment.t.sol
+++ b/test/environment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 import "./utils/losslessEnv.t.sol";
 

--- a/test/protectedWLERC20.t.sol
+++ b/test/protectedWLERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "./utils/losslessEnv.t.sol";
 

--- a/test/utils/losslessEnv.t.sol
+++ b/test/utils/losslessEnv.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";


### PR DESCRIPTION
### [MEDIUM] CWE-400: Optimization of Blacklisted Funds Handling

As only a max of two blacklisted addresses would be processed at a time (originating from `report(...)` and `secondReport(...)`) it has been decided to avoid adding complex logic to this function.

### [LOW] CWE-862: Insecure Default Admin Role

The decision to use a multi-sig is left to the user, this is recommended multiple times in the documentation, as for smaller protocols might not be entirely feasible. For this reasons it was decided to not add the recommended logic.

### [LOW] CWE-453: Front-running

It has been decided to not include changes for this point as the logic of these contracts are not in scope of providing financial protection to the protocols. The users can decide to add it if needed.
